### PR TITLE
Fixed crash and compile error

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You must do it as root, as hamachi is owned by root:
 
 1) Compile the malloc() interceptor shared object library:
 
-	gcc -O2 -Wall -o hamachid-patcher.so -shared hamachid-patcher.c
+	gcc -O2 -Wall -fPIC -o hamachid-patcher.so -shared hamachid-patcher.c
 	
 2) Compile the hamachid program wrapper:
 

--- a/compile.sh
+++ b/compile.sh
@@ -1,2 +1,2 @@
-gcc -O2 -Wall -o hamachid-patcher.so -shared hamachid-patcher.c
+gcc -O2 -Wall -fPIC -o hamachid-patcher.so -shared hamachid-patcher.c
 gcc -O2 -Wall -o hamachid hamachid.c

--- a/hamachid-patcher.c
+++ b/hamachid-patcher.c
@@ -950,7 +950,7 @@ static void init(void) {
         LOG("%s", error);
         exit(1);
     }
-    pfn_cfree = (pfn_cfree_t) dlsym(RTLD_NEXT, "cfree");
+    pfn_cfree = (pfn_cfree_t) dlsym(RTLD_NEXT, "free");
     if ((error = dlerror()) != NULL) {
         LOG("%s", error);
         exit(1);

--- a/installer.sh
+++ b/installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 function Install(){
 echo -e "\033[01;32mInstalling . . . . . . . . "
-gcc -O2 -Wall -o hamachid-patcher.so -shared hamachid-patcher.c
+gcc -O2 -Wall -fPIC -o hamachid-patcher.so -shared hamachid-patcher.c
 gcc -O2 -Wall -o hamachid hamachid.c
 sudo mv /opt/logmein-hamachi/bin/hamachid /opt/logmein-hamachi/bin/hamachid.org
 sudo cp hamachid-patcher.so /opt/logmein-hamachi/bin/


### PR DESCRIPTION
Running Fedora 39, I ran into the same issues described in #7 and #8. The compile error was straightforward, just add the `-fPIC` argument as required. For the segfault, I traced the problem to a call to `cfree`. According to https://man7.org/linux/man-pages/man3/cfree.3.html, `cfree` in glibc is a synonym for `free`, so I replaced the symbol name "cfree" with "free" when calling `dlsym`.

With these modifications I was able to get things working, but ideally someone needs to test it on Ubuntu as well.